### PR TITLE
Add onchain wallet object

### DIFF
--- a/app/src/main/java/com/example/umlandowallet/DispatchActivity.kt
+++ b/app/src/main/java/com/example/umlandowallet/DispatchActivity.kt
@@ -4,7 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
-import org.bitcoindevkit.*
+import com.example.umlandowallet.data.OnchainWallet
 import java.io.File
 
 private const val TAG = "DispatchActivity"
@@ -12,12 +12,6 @@ private const val TAG = "DispatchActivity"
 class DispatchActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        val blockchain = createBlockchain()
-        Global.blockchain = blockchain
-
-        var latestBlockHeight = blockchain.getHeight()
-        var latestBlockHash = blockchain.getBlockHash(latestBlockHeight)
 
         Global.homeDir = filesDir.absolutePath + "/uMlando"
         val directory = File(Global.homeDir)
@@ -30,7 +24,11 @@ class DispatchActivity : AppCompatActivity() {
         val ldkDataDirectory = File(Global.homeDir)
         if(!ldkDataDirectory.exists()) {
             ldkDataDirectory.mkdir()
+            Log.i(TAG, "Creating directory at $ldkDataDirectory")
         }
+
+        val latestBlockHeight = OnchainWallet.getHeight()
+        val latestBlockHash = OnchainWallet.getBlockHash(latestBlockHeight)
 
         var serializedChannelManager = ""
         var serializedChannelMonitors = ""
@@ -41,68 +39,21 @@ class DispatchActivity : AppCompatActivity() {
                 serializedChannelManager = it.absoluteFile.readText(Charsets.UTF_8)
             }
             if(it.name.startsWith(Global.prefixChannelMonitor)) {
-                val serializedMonitor = it.absoluteFile.readText(Charsets.UTF_8);
+                val serializedMonitor = it.absoluteFile.readText(Charsets.UTF_8)
                 monitors = monitors.plus(serializedMonitor)
             }
         }
 
         serializedChannelMonitors = monitors.joinToString(separator = ",")
 
-        var mnemonic: String
-
-        try {
-            mnemonic = File(Global.homeDir + "/" + "mnemonic").readText()
-        } catch (e: Throwable) {
-            // if mnemonic doesn't exist, generate one and save it
-            Log.i(TAG, "No mnemonic backup, we'll create a new wallet")
-            mnemonic = generateMnemonic(WordCount.WORDS12)
-            File(Global.homeDir + "/" + "mnemonic").writeText(mnemonic)
-        }
-        
-        val descriptorSecretKey = DescriptorSecretKey(Network.REGTEST, mnemonic, null)
-
-        val derivedKey = descriptorSecretKey.derive(DerivationPath("m/84h/1h/0h"))
-        val externalDescriptor = "wpkh(${derivedKey.extend(DerivationPath("m/0")).asString()})"
-        val internalDescriptor = "wpkh(${derivedKey.extend(DerivationPath("m/1")).asString()})"
-
-        val ldkEntropy = getEntropy(mnemonic)
-
-        val databaseConfig = DatabaseConfig.Memory
-
-        Global.wallet = Wallet(
-            internalDescriptor,
-            externalDescriptor,
-            Network.REGTEST,
-            databaseConfig,
+        start(
+            OnchainWallet.getLdkEntropy(),
+            latestBlockHeight.toInt(),
+            latestBlockHash,
+            serializedChannelManager,
+            serializedChannelMonitors
         )
-
-        Log.i(TAG, "Successfully created/restored wallet with mnemonic $mnemonic")
-
-        start(ldkEntropy.toHex(), latestBlockHeight.toInt(), latestBlockHash, serializedChannelManager, serializedChannelMonitors)
 
         startActivity(Intent(this, MainActivity::class.java))
     }
-}
-
-@OptIn(ExperimentalUnsignedTypes::class)
-private fun getEntropy(mnemonic: String): ByteArray {
-    val bip32RootKey: DescriptorSecretKey = DescriptorSecretKey(
-        network = Network.REGTEST,
-        mnemonic = mnemonic,
-        password = null,
-    )
-    val derivationPath = DerivationPath("m/535h")
-    val child: DescriptorSecretKey = bip32RootKey.derive(derivationPath)
-    val entropy: ByteArray = child.secretBytes().toUByteArray().toByteArray()
-
-    println("Entropy used for LDK is ${entropy.toHex()}")
-    return entropy
-}
-
-fun createBlockchain(): Blockchain {
-    val esploraURL: String = "http://10.0.2.2:3002"
-
-    val blockchainConfig = BlockchainConfig.Esplora(EsploraConfig(esploraURL, null, 5u, 20u, null))
-
-    return Blockchain(blockchainConfig)
 }

--- a/app/src/main/java/com/example/umlandowallet/Global.kt
+++ b/app/src/main/java/com/example/umlandowallet/Global.kt
@@ -1,53 +1,48 @@
 package com.example.umlandowallet
 
-import android.app.Application
-import org.bitcoindevkit.Blockchain
-import org.bitcoindevkit.Wallet
 import org.ldk.batteries.ChannelManagerConstructor
 import org.ldk.batteries.NioPeerHandler
 import org.ldk.structs.*
 
-class Global : Application() {
-    companion object {
-        @JvmField
-        var homeDir: String = ""
-        val prefixChannelMonitor = "channel_monitor_"
-        val prefixChannelManager = "channel_manager"
-        val prefixNetworkGraph = "network_graph.bin"
-        val prefixScorer = "scorer"
+object Global {
+    @JvmField
+    var homeDir: String = ""
+    val prefixChannelMonitor = "channel_monitor_"
+    val prefixChannelManager = "channel_manager"
+    val prefixNetworkGraph = "network_graph.bin"
+    val prefixScorer = "scorer"
 
 
-        val feerateFast = 5000 // estimate fee rate in BTC/kB
-        val feerateMedium = 5000 // estimate fee rate in BTC/kB
-        val feerateSlow = 5000 // estimate fee rate in BTC/kB
+    val feerateFast = 5000 // estimate fee rate in BTC/kB
+    val feerateMedium = 5000 // estimate fee rate in BTC/kB
+    val feerateSlow = 5000 // estimate fee rate in BTC/kB
 
-        var eventsTxBroadcast: Array<String> = arrayOf<String>()
-        var eventsPaymentSent: Array<String> = arrayOf<String>()
-        var eventsPaymentPathFailed: Array<String> = arrayOf<String>()
-        var eventsPaymentFailed: Array<String> = arrayOf<String>()
-        var eventsPaymentReceived: Array<String> = arrayOf<String>()
-        var eventsFundingGenerationReady: Array<String> = arrayOf<String>()
-        var eventsPaymentForwarded: Array<String> = arrayOf<String>()
-        var eventsChannelClosed: Array<String> = arrayOf<String>()
-        var eventsRegisterTx: Array<String> = arrayOf<String>()
-        var eventsRegisterOutput: Array<String> = arrayOf<String>()
+    var eventsTxBroadcast: Array<String> = arrayOf<String>()
+    var eventsPaymentSent: Array<String> = arrayOf<String>()
+    var eventsPaymentPathFailed: Array<String> = arrayOf<String>()
+    var eventsPaymentFailed: Array<String> = arrayOf<String>()
+    var eventsPaymentReceived: Array<String> = arrayOf<String>()
+    var eventsFundingGenerationReady: Array<String> = arrayOf<String>()
+    var eventsPaymentForwarded: Array<String> = arrayOf<String>()
+    var eventsChannelClosed: Array<String> = arrayOf<String>()
+    var eventsRegisterTx: Array<String> = arrayOf<String>()
+    var eventsRegisterOutput: Array<String> = arrayOf<String>()
 
-        var refundAddressScript = ""
+    var refundAddressScript = ""
 
-        var wallet: Wallet? = null
-        var channelManager: ChannelManager? = null
-        var keysManager: KeysManager? = null
-        var chainMonitor: ChainMonitor? = null
-        var temporaryChannelId: ByteArray? = null
-        var counterpartyNodeId: ByteArray? = null
-        var channelManagerConstructor: ChannelManagerConstructor? = null
-        var nioPeerHandler: NioPeerHandler? = null
-        var peerManager: PeerManager? = null
+    // var wallet: Wallet? = null
+    var channelManager: ChannelManager? = null
+    var keysManager: KeysManager? = null
+    var chainMonitor: ChainMonitor? = null
+    var temporaryChannelId: ByteArray? = null
+    var counterpartyNodeId: ByteArray? = null
+    var channelManagerConstructor: ChannelManagerConstructor? = null
+    var nioPeerHandler: NioPeerHandler? = null
+    var peerManager: PeerManager? = null
 
-        var router: NetworkGraph? = null
-        var p2pGossipSync: P2PGossipSync? = null
-        var txFilter: Filter? = null
-        var blockchain: Blockchain? = null
-        var scorer: MultiThreadedLockableScore? = null
-    }
+    var router: NetworkGraph? = null
+    var p2pGossipSync: P2PGossipSync? = null
+    var txFilter: Filter? = null
+    // var blockchain: Blockchain? = null
+    var scorer: MultiThreadedLockableScore? = null
 }

--- a/app/src/main/java/com/example/umlandowallet/HandleEvent.kt
+++ b/app/src/main/java/com/example/umlandowallet/HandleEvent.kt
@@ -1,6 +1,6 @@
 package com.example.umlandowallet
 
-import com.example.umlandowallet.ui.buildFundingTx
+import com.example.umlandowallet.data.OnchainWallet
 import org.ldk.structs.*
 
 fun handleEvent(event: Event) {
@@ -21,7 +21,7 @@ fun handleEvent(event: Event) {
             storeEvent("${Global.homeDir}/events_funding_generation_ready", params)
             Global.eventsFundingGenerationReady = Global.eventsFundingGenerationReady.plus(params.toString())
 
-            val rawTx = buildFundingTx(event.channel_value_satoshis, event.output_script)
+            val rawTx = OnchainWallet.buildFundingTx(event.channel_value_satoshis, event.output_script)
 
             Global.channelManager!!.funding_transaction_generated(
                 event.temporary_channel_id,

--- a/app/src/main/java/com/example/umlandowallet/Start.kt
+++ b/app/src/main/java/com/example/umlandowallet/Start.kt
@@ -14,7 +14,7 @@ import java.io.IOException
 import java.net.InetSocketAddress
 
 fun start(
-    entropy: String,
+    entropy: ByteArray,
     latestBlockHeight: Int,
     latestBlockHash: String,
     serializedChannelManager: String,
@@ -53,7 +53,7 @@ fun start(
 
     // Providing keys for signing lightning transactions
     Global.keysManager = KeysManager.of(
-        entropy.toByteArray(),
+        entropy,
         System.currentTimeMillis() / 1000,
         (System.currentTimeMillis() * 1000).toInt()
     )

--- a/app/src/main/java/com/example/umlandowallet/data/OnchainWallet.kt
+++ b/app/src/main/java/com/example/umlandowallet/data/OnchainWallet.kt
@@ -1,0 +1,128 @@
+package com.example.umlandowallet.data
+
+import android.util.Log
+import com.example.umlandowallet.Global
+import com.example.umlandowallet.toHex
+import org.bitcoindevkit.*
+import java.io.File
+
+private const val TAG = "OnchainWallet"
+
+// The onchain wallet is currently always in regtest mode
+object OnchainWallet {
+    private lateinit var onchainWallet: Wallet
+    private val blockchain: Blockchain = createBlockchain()
+
+    init {
+        createOnchainWallet()
+    }
+
+    private fun createOnchainWallet() {
+        val mnemonic = loadMnemonic()
+        val descriptorSecretKey = DescriptorSecretKey(Network.REGTEST, mnemonic, null)
+        val derivedKey = descriptorSecretKey.derive(DerivationPath("m/84h/1h/0h"))
+        val externalDescriptor = "wpkh(${derivedKey.extend(DerivationPath("m/0")).asString()})"
+        val internalDescriptor = "wpkh(${derivedKey.extend(DerivationPath("m/1")).asString()})"
+        val databaseConfig = DatabaseConfig.Memory
+
+        onchainWallet = Wallet(
+            internalDescriptor,
+            externalDescriptor,
+            Network.REGTEST,
+            databaseConfig,
+        )
+        Log.i(TAG, "Successfully created/restored wallet with mnemonic $mnemonic")
+    }
+
+    fun getNewAddress(): String {
+        return onchainWallet.getAddress(AddressIndex.NEW).address
+    }
+
+    fun getBalance(): String {
+        return onchainWallet.getBalance().toString()
+    }
+
+    fun sync() {
+        onchainWallet.sync(
+            blockchain = blockchain,
+            progress = LogProgress
+        )
+    }
+
+    fun getHeight(): UInt {
+        return blockchain.getHeight()
+    }
+
+    fun getBlockHash(height: UInt): String {
+        return blockchain.getBlockHash(height)
+    }
+
+    @OptIn(ExperimentalUnsignedTypes::class)
+    fun getLdkEntropy(): ByteArray {
+        val mnemonic: String = loadMnemonic()
+        val bip32RootKey: DescriptorSecretKey = DescriptorSecretKey(
+            network = Network.REGTEST,
+            mnemonic = mnemonic,
+            password = null,
+        )
+        val derivationPath = DerivationPath("m/535h")
+        val child: DescriptorSecretKey = bip32RootKey.derive(derivationPath)
+        val entropy: ByteArray = child.secretBytes().toUByteArray().toByteArray()
+
+        Log.i(TAG, "Entropy used for LDK is ${entropy.toHex()}")
+        return entropy
+    }
+
+    @OptIn(ExperimentalUnsignedTypes::class)
+    fun buildFundingTx(value: Long, script: ByteArray): ByteArray {
+        sync()
+        val scriptListUByte: List<UByte> = script.toUByteArray().asList()
+        val outputScript: Script = Script(scriptListUByte)
+        val (psbt, txDetails) = TxBuilder()
+            .addRecipient(outputScript, value.toULong())
+            .feeRate(4.0F)
+            .finish(onchainWallet)
+        sign(psbt)
+        val rawTx = psbt.extractTx().toUByteArray().toByteArray()
+        println("The raw funding tx is ${rawTx.toHex()}")
+        return rawTx
+    }
+
+    private fun sign(psbt: PartiallySignedBitcoinTransaction) {
+        onchainWallet.sign(psbt)
+    }
+
+    fun broadcast(signedPsbt: PartiallySignedBitcoinTransaction): String {
+        val blockchain = createBlockchain()
+        blockchain.broadcast(signedPsbt)
+        return signedPsbt.txid()
+    }
+
+    private fun createBlockchain(): Blockchain {
+        val esploraURL: String = "http://10.0.2.2:3002"
+        val blockchainConfig = BlockchainConfig.Esplora(EsploraConfig(esploraURL, null, 5u, 20u, null))
+        return Blockchain(blockchainConfig)
+    }
+
+    private fun loadMnemonic(): String {
+        try {
+            return File(Global.homeDir + "/" + "mnemonic.txt").readText()
+        } catch (e: Throwable) {
+            // if mnemonic doesn't exist, generate one and save it
+            Log.i(TAG, "No mnemonic backup, we'll create a new wallet")
+            val mnemonic = generateMnemonic(WordCount.WORDS12)
+            File(Global.homeDir + "/" + "mnemonic.txt").writeText(mnemonic)
+            return mnemonic
+        }
+    }
+
+    fun recoveryPhrase(): String {
+        return File(Global.homeDir + "/" + "mnemonic.txt").readText()
+    }
+
+    object LogProgress: Progress {
+        override fun update(progress: Float, message: String?) {
+            Log.d(TAG, "updating wallet $progress $message")
+        }
+    }
+}

--- a/app/src/main/java/com/example/umlandowallet/data/remote/Access.kt
+++ b/app/src/main/java/com/example/umlandowallet/data/remote/Access.kt
@@ -1,15 +1,14 @@
 package com.example.umlandowallet.data.remote
 
-import com.example.umlandowallet.Global
+import com.example.umlandowallet.data.OnchainWallet
 import org.bitcoindevkit.*
 import org.ldk.structs.ChainMonitor
 import org.ldk.structs.ChannelManager
-import java.io.File
 
 interface Access {
     suspend fun sync(): Unit
 
-    suspend fun syncWallet(wallet: Wallet, logProgress: Progress): Unit
+    suspend fun syncWallet(onchainWallet: OnchainWallet): Unit
 
     suspend fun syncBestBlockConnected(
         channelManager: ChannelManager,

--- a/app/src/main/java/com/example/umlandowallet/data/remote/AccessImpl.kt
+++ b/app/src/main/java/com/example/umlandowallet/data/remote/AccessImpl.kt
@@ -1,15 +1,9 @@
 package com.example.umlandowallet.data.remote
 
-import com.example.umlandowallet.data.ConfirmedTx
-import com.example.umlandowallet.data.Tx
-import com.example.umlandowallet.data.TxResponse
-import com.example.umlandowallet.data.TxStatus
+import com.example.umlandowallet.data.*
 import com.example.umlandowallet.toByteArray
 import com.example.umlandowallet.toHex
-import com.example.umlandowallet.ui.LogProgress
 import org.bitcoindevkit.Blockchain
-import org.bitcoindevkit.Progress
-import org.bitcoindevkit.Wallet
 import org.ldk.structs.ChainMonitor
 import org.ldk.structs.ChannelManager
 import org.ldk.structs.TwoTuple_usizeTransactionZ
@@ -21,8 +15,8 @@ class AccessImpl(
         val currentHeight = blockchain.getHeight()
     }
 
-    override suspend fun syncWallet(wallet: Wallet, logProgress: Progress) {
-        wallet.sync(blockchain, LogProgress)
+    override suspend fun syncWallet(onchainWallet: OnchainWallet) {
+        onchainWallet.sync()
     }
 
     override suspend fun syncBestBlockConnected(

--- a/app/src/main/java/com/example/umlandowallet/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/umlandowallet/ui/SettingsScreen.kt
@@ -14,9 +14,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
-import com.example.umlandowallet.Global
 import com.example.umlandowallet.R
-import org.bitcoindevkit.AddressIndex
+import com.example.umlandowallet.data.OnchainWallet
 
 private const val TAG = "SettingsScreen"
 
@@ -134,13 +133,14 @@ fun SettingsScreen(navController: NavController) {
         // Get new address
         SettingButton(
             label = "Get new address",
-            onClick = { Log.i(TAG, "New bitcoin address: ${Global.wallet!!.getAddress(AddressIndex.NEW).address}") }
+            onClick = { Log.i(TAG, "New bitcoin address: ${OnchainWallet.getNewAddress()}") }
+            // onClick = { Log.i(TAG, "New bitcoin address: ${Global.wallet!!.getAddress(AddressIndex.NEW).address}") }
         )
 
         // Get balance
         SettingButton(
             label = "Get balance",
-            onClick = { Log.i(TAG, "On chain balance: ${Global.wallet!!.getBalance()}") }
+            onClick = { Log.i(TAG, "On chain balance: ${OnchainWallet.getBalance()}") }
         )
     }
 }

--- a/app/src/main/java/com/example/umlandowallet/ui/settings/RecoveryPhraseScreen.kt
+++ b/app/src/main/java/com/example/umlandowallet/ui/settings/RecoveryPhraseScreen.kt
@@ -8,8 +8,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.umlandowallet.Global
-import java.io.File
+import com.example.umlandowallet.data.OnchainWallet
 
 @Composable
 fun RecoveryPhraseScreen() {
@@ -27,9 +26,8 @@ fun RecoveryPhraseScreen() {
                 .padding(start = 24.dp, end = 24.dp, bottom = 24.dp)
         )
 
-        val nodeIdByteArray = Global.channelManager?._our_node_id
         Text(
-            text = File(Global.homeDir + "/" + "mnemonic").readText(),
+            text = OnchainWallet.recoveryPhrase(),
             modifier = Modifier.padding(start = 24.dp, end = 24.dp)
         )
     }


### PR DESCRIPTION
This PR adds the `OnchainWallet` object which groups together most of the tasks related to onchain stuff.

Calls throughout the app now become `OnchainWallet.sync()`, `OnchainWallet.getNewAddress()`, or `OnchainWallet.buildFundingTx()`.

Also worthy of review is the fact that I wasn't sure if the `Global` object really needed to be extending the Android `Application` class. I refactored it to be just a singleton, and it appears to be working fine on my end. Let me know if you'd prefer to keep it as it was.