### PR TITLE
Use global tag for logging to start

### DIFF
--- a/app/src/main/java/com/example/umlandowallet/DispatchActivity.kt
+++ b/app/src/main/java/com/example/umlandowallet/DispatchActivity.kt
@@ -5,9 +5,8 @@ import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.example.umlandowallet.data.OnchainWallet
+import com.example.umlandowallet.utils.LDKTAG
 import java.io.File
-
-private const val TAG = "DispatchActivity"
 
 class DispatchActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -24,7 +23,7 @@ class DispatchActivity : AppCompatActivity() {
         val ldkDataDirectory = File(Global.homeDir)
         if(!ldkDataDirectory.exists()) {
             ldkDataDirectory.mkdir()
-            Log.i(TAG, "Creating directory at $ldkDataDirectory")
+            Log.i(LDKTAG, "Creating directory at $ldkDataDirectory")
         }
 
         val latestBlockHeight = OnchainWallet.getHeight()
@@ -53,10 +52,6 @@ class DispatchActivity : AppCompatActivity() {
             serializedChannelManager,
             serializedChannelMonitors
         )
-
-        Log.i(TAG, "Successfully created/restored wallet with mnemonic $mnemonic")
-
-        start(ldkEntropy, latestBlockHeight.toInt(), latestBlockHash, serializedChannelManager, serializedChannelMonitors)
 
         startActivity(Intent(this, MainActivity::class.java))
     }

--- a/app/src/main/java/com/example/umlandowallet/HandleEvent.kt
+++ b/app/src/main/java/com/example/umlandowallet/HandleEvent.kt
@@ -1,12 +1,14 @@
 package com.example.umlandowallet
 
+import android.util.Log
 import com.example.umlandowallet.data.OnchainWallet
+import com.example.umlandowallet.utils.LDKTAG
 import org.ldk.structs.*
 import kotlin.random.Random
 
 fun handleEvent(event: Event) {
     if (event is Event.FundingGenerationReady) {
-        println("FundingGenerationReady")
+        Log.i(LDKTAG, "FundingGenerationReady")
         val funding_spk = event.output_script
         if (funding_spk.size == 34 && funding_spk[0].toInt() == 0 && funding_spk[1].toInt() == 32) {
             val params = WritableMap()
@@ -14,6 +16,7 @@ fun handleEvent(event: Event) {
             params.putString("counterparty_node_id", event.counterparty_node_id.toHex())
             params.putString("channel_value_satoshis", event.channel_value_satoshis.toString())
             params.putString("output_script", event.output_script.toHex())
+            Log.i(LDKTAG, "Output script is ${event.output_script.toHex()}")
             params.putString("temporary_channel_id", event.temporary_channel_id.toHex())
             params.putString("user_channel_id", event.user_channel_id.toString())
             Global.temporaryChannelId = event.temporary_channel_id
@@ -54,9 +57,9 @@ fun handleEvent(event: Event) {
     }
 
     if (event is Event.ChannelClosed) {
-        println("ChannelClosed");
+        Log.i(LDKTAG, "ChannelClosed")
         val params = WritableMap()
-        val reason = event.reason;
+        val reason = event.reason
         params.putString("channel_id", event.channel_id.toHex())
         params.putString("user_channel_id", event.user_channel_id.toString())
 

--- a/app/src/main/java/com/example/umlandowallet/data/OnchainWallet.kt
+++ b/app/src/main/java/com/example/umlandowallet/data/OnchainWallet.kt
@@ -3,10 +3,9 @@ package com.example.umlandowallet.data
 import android.util.Log
 import com.example.umlandowallet.Global
 import com.example.umlandowallet.toHex
+import com.example.umlandowallet.utils.LDKTAG
 import org.bitcoindevkit.*
 import java.io.File
-
-private const val TAG = "OnchainWallet"
 
 // The onchain wallet is currently always in regtest mode
 object OnchainWallet {
@@ -31,7 +30,7 @@ object OnchainWallet {
             Network.REGTEST,
             databaseConfig,
         )
-        Log.i(TAG, "Successfully created/restored wallet with mnemonic $mnemonic")
+        Log.i(LDKTAG, "Successfully created/restored wallet with mnemonic $mnemonic")
     }
 
     fun getNewAddress(): String {
@@ -69,7 +68,7 @@ object OnchainWallet {
         val child: DescriptorSecretKey = bip32RootKey.derive(derivationPath)
         val entropy: ByteArray = child.secretBytes().toUByteArray().toByteArray()
 
-        Log.i(TAG, "Entropy used for LDK is ${entropy.toHex()}")
+        Log.i(LDKTAG, "Entropy used for LDK is ${entropy.toHex()}")
         return entropy
     }
 
@@ -84,7 +83,7 @@ object OnchainWallet {
             .finish(onchainWallet)
         sign(psbt)
         val rawTx = psbt.extractTx().toUByteArray().toByteArray()
-        println("The raw funding tx is ${rawTx.toHex()}")
+        Log.i(LDKTAG, "The raw funding tx is ${rawTx.toHex()}")
         return rawTx
     }
 
@@ -109,7 +108,7 @@ object OnchainWallet {
             return File(Global.homeDir + "/" + "mnemonic.txt").readText()
         } catch (e: Throwable) {
             // if mnemonic doesn't exist, generate one and save it
-            Log.i(TAG, "No mnemonic backup, we'll create a new wallet")
+            Log.i(LDKTAG, "No mnemonic backup, we'll create a new wallet")
             val mnemonic = generateMnemonic(WordCount.WORDS12)
             File(Global.homeDir + "/" + "mnemonic.txt").writeText(mnemonic)
             return mnemonic
@@ -122,7 +121,7 @@ object OnchainWallet {
 
     object LogProgress: Progress {
         override fun update(progress: Float, message: String?) {
-            Log.d(TAG, "updating wallet $progress $message")
+            Log.d(LDKTAG, "updating wallet $progress $message")
         }
     }
 }

--- a/app/src/main/java/com/example/umlandowallet/data/remote/AccessImpl.kt
+++ b/app/src/main/java/com/example/umlandowallet/data/remote/AccessImpl.kt
@@ -25,8 +25,8 @@ class AccessImpl(
     ) {
         val service = Service.create()
 
-        val height = service.getlatestBlockHeight()
-        val hash = service.getlatestBlockHash()
+        val height = service.getLatestBlockHeight()
+        val hash = service.getLatestBlockHash()
         val header = service.getHeader(hash)
 
         channelManager.as_Confirm().best_block_updated(header.toByteArray(), height)

--- a/app/src/main/java/com/example/umlandowallet/data/remote/ServiceImpl.kt
+++ b/app/src/main/java/com/example/umlandowallet/data/remote/ServiceImpl.kt
@@ -1,11 +1,13 @@
 package com.example.umlandowallet.data.remote
 
+import android.util.Log
 import com.example.umlandowallet.Global
 import com.example.umlandowallet.data.MerkleProof
 import com.example.umlandowallet.data.Tx
 import com.example.umlandowallet.data.TxStatus
 import com.example.umlandowallet.toByteArray
 import com.example.umlandowallet.toHex
+import com.example.umlandowallet.utils.LDKTAG
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
@@ -55,16 +57,16 @@ class ServiceImpl(private val client: HttpClient) : Service {
     }
 
     override suspend fun connectPeer(pubkeyHex: String, hostname: String, port: Int): Boolean {
-        println("LDK: attempting to connect to peer $pubkeyHex")
+        Log.i(LDKTAG, "LDK: attempting to connect to peer $pubkeyHex")
         return try {
             Global.nioPeerHandler!!.connect(
                 pubkeyHex.toByteArray(),
                 InetSocketAddress(hostname, port), 5555
             )
-            println("LDK: successfully connected to peer $pubkeyHex")
+            Log.i(LDKTAG, "LDK: successfully connected to peer $pubkeyHex")
             true
         } catch (e: IOException) {
-            println("connectPeer exception: " + e.message)
+            Log.i(LDKTAG, "connectPeer exception: " + e.message)
             false
         }
     }

--- a/app/src/main/java/com/example/umlandowallet/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/umlandowallet/ui/SettingsScreen.kt
@@ -16,8 +16,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.example.umlandowallet.R
 import com.example.umlandowallet.data.OnchainWallet
-
-private const val TAG = "SettingsScreen"
+import com.example.umlandowallet.utils.LDKTAG
 
 @Composable
 fun SettingsScreen(navController: NavController) {
@@ -133,14 +132,13 @@ fun SettingsScreen(navController: NavController) {
         // Get new address
         SettingButton(
             label = "Get new address",
-            onClick = { Log.i(TAG, "New bitcoin address: ${OnchainWallet.getNewAddress()}") }
-            // onClick = { Log.i(TAG, "New bitcoin address: ${Global.wallet!!.getAddress(AddressIndex.NEW).address}") }
+            onClick = { Log.i(LDKTAG, "New bitcoin address: ${OnchainWallet.getNewAddress()}") }
         )
 
         // Get balance
         SettingButton(
             label = "Get balance",
-            onClick = { Log.i(TAG, "On chain balance: ${OnchainWallet.getBalance()}") }
+            onClick = { Log.i(LDKTAG, "On chain balance: ${OnchainWallet.getBalance()}") }
         )
     }
 }

--- a/app/src/main/java/com/example/umlandowallet/ui/WalletScreen.kt
+++ b/app/src/main/java/com/example/umlandowallet/ui/WalletScreen.kt
@@ -14,11 +14,10 @@ import com.example.umlandowallet.ChannelManagerEventHandler
 import com.example.umlandowallet.Global
 import com.example.umlandowallet.data.OnchainWallet
 import com.example.umlandowallet.data.remote.Access
+import com.example.umlandowallet.utils.LDKTAG
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-
-private const val TAG = "WalletScreen"
 
 @Composable
 fun WalletScreen() {
@@ -68,7 +67,7 @@ fun WalletScreen() {
                         ChannelManagerEventHandler, Global.scorer!!)
                 }
 
-                Log.i(TAG, "Wallet synced")
+                Log.i(LDKTAG, "Wallet synced")
             },
             modifier = Modifier
                 .padding(start = 24.dp, end = 24.dp)

--- a/app/src/main/java/com/example/umlandowallet/ui/settings/OpenChannelScreen.kt
+++ b/app/src/main/java/com/example/umlandowallet/ui/settings/OpenChannelScreen.kt
@@ -1,5 +1,6 @@
 package com.example.umlandowallet.ui.settings
 
+import android.util.Log
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -13,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.umlandowallet.Global
 import com.example.umlandowallet.toByteArray
+import com.example.umlandowallet.utils.LDKTAG
 import org.ldk.structs.ChannelHandshakeConfig
 import org.ldk.structs.Result__u832APIErrorZ
 import org.ldk.structs.UserConfig
@@ -80,10 +82,10 @@ fun createChannel(pubKey: String) {
     )
 
     if (createChannelResult !is Result__u832APIErrorZ.Result__u832APIErrorZ_OK) {
-        println("ERROR: failed to open channel with: $pubKey")
+        Log.i(LDKTAG, "ERROR: failed to open channel with: $pubKey")
     }
 
     if(createChannelResult.is_ok) {
-        println("EVENT: initiated channel with peer: $pubKey")
+        Log.i(LDKTAG, "EVENT: initiated channel with peer: $pubKey")
     }
 }

--- a/app/src/main/java/com/example/umlandowallet/utils/Tags.kt
+++ b/app/src/main/java/com/example/umlandowallet/utils/Tags.kt
@@ -1,0 +1,3 @@
+package com.example.umlandowallet.utils
+
+const val LDKTAG = "LDKTAG"


### PR DESCRIPTION
I initially had written a few of the logging lines in a more traditional way with a specific tag for each file/class, but I'm now changing my tune; I think for now it makes sense to have more like a global tag to start, and _maybe_ customize if or when it's required for specific logging entries.

This PR simply creates a global default tag I called `LDKTAG` (not sure about the name but I needed something), and switches all log entries in the current app to use that tag. This makes it very easy to follow all tags emitted by us. I also fixed a small bug I introduced in the previous refactoring (capitalization of the `getLatestBlockHash()` method).

<img width="1000" alt="logs" src="https://user-images.githubusercontent.com/39974688/200576422-d48bff6d-574d-4742-9a8a-10ba53f705ad.png">


