### PR TITLE
Add composable to control system bars colour and visibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout-compose:1.0.1'
     implementation 'com.google.accompanist:accompanist-navigation-animation:0.23.1'
+    implementation 'com.google.accompanist:accompanist-systemuicontroller:0.23.1'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/com/example/umlandowallet/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/umlandowallet/ui/HomeScreen.kt
@@ -13,11 +13,13 @@ import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import com.example.umlandowallet.utils.NavigationItem
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
 @Composable
 internal fun HomeScreen() {
     val navController: NavHostController = rememberAnimatedNavController()
+    SystemBars()
 
     Scaffold(bottomBar = { BottomNavigationBar(navController) }) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
@@ -74,5 +76,21 @@ internal fun BottomNavigationBar(navController: NavController) {
                 )
             )
         }
+    }
+}
+
+@Composable
+internal fun SystemBars() {
+    rememberSystemUiController().apply {
+        setStatusBarColor(
+            color = Color.Transparent,
+            darkIcons = true
+        )
+        // setNavigationBarColor(
+        //     color = Color.Transparent,
+        //     darkIcons = true
+        // )
+        // this.isNavigationBarVisible = false
+        // this.isStatusBarVisible = false
     }
 }


### PR DESCRIPTION
This PR adds the ability to control whether the two system bars (status bar up top and navigation bar at the bottom) are visible and the colours/transparency they should have.

For now I simply made the status bar transparent so as to remove the blue stripe we had at the top, but I also added and commented out the code to change the navigation bar and show/hide either of them, just so we have the option and it's easy to change. It's a surprisingly simple little composable:

```kotlin
@Composable
internal fun SystemBars() {
    rememberSystemUiController().apply {
        setStatusBarColor(
            color = Color.Transparent,
            darkIcons = true
        )
        // setNavigationBarColor(
        //     color = Color.Transparent,
        //     darkIcons = true
        // )
        // this.isNavigationBarVisible = false
        // this.isStatusBarVisible = false
    }
}
```